### PR TITLE
Deref to a byte slice in order to read and write from the page

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,10 @@ impl Page {
       buffer: buf,
     }
   }
+
+  pub fn offset(&self) -> usize {
+      self.offset
+  }
 }
 
 impl Deref for Page {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,8 +10,10 @@
 //!
 //! let pager = memory_pager::Pager::new(1024);
 //! let page = pager.get(3);
-//! assert_eq!(page.buffer.len(), 1024);
+//! assert_eq!(page.len(), 1024);
 //! ```
+
+use std::ops::{Deref, DerefMut};
 
 /// Memory pager instance. Manages [`Page`] instances.
 ///
@@ -32,11 +34,11 @@ pub struct Pager {
 pub struct Page {
   /// Byte offset for the start of the `Page` relative to all other `Page`
   /// instances.
-  pub offset: usize,
+  offset: usize,
   /// Buffer with capacity of size [`page_size`].
   ///
   /// [`page_size`]: struct.Pager.html#structfield.page_size
-  pub buffer: Vec<u8>,
+  buffer: Vec<u8>,
 }
 
 impl Page {
@@ -46,6 +48,19 @@ impl Page {
       buffer: buf,
     }
   }
+}
+
+impl Deref for Page {
+    type Target = [u8];
+    fn deref(&self) -> &Self::Target {
+        &self.buffer
+    }
+}
+
+impl DerefMut for Page {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.buffer
+    }
 }
 
 impl Pager {
@@ -74,7 +89,7 @@ impl Pager {
   pub fn with_pages(page_size: usize, pages: Vec<Option<Page>>) -> Self {
     for page in &pages {
       if let &Some(ref page) = page {
-        assert_eq!(page.buffer.len(), page_size);
+        assert_eq!(page.len(), page_size);
       }
     }
 
@@ -104,6 +119,27 @@ impl Pager {
     }
 
     self.pages[page_num].as_ref().unwrap()
+  }
+
+  /// Get a [`Page`]. The page will be allocated on first access.
+  ///
+  /// [`Page`]: struct.Page.html
+  pub fn get_mut(&mut self, page_num: usize) -> &mut Page {
+    if page_num >= self.pages.capacity() {
+      self.grow_pages(page_num);
+    }
+
+    // This should never be out of bounds.
+    if let None = self.pages[page_num] {
+      let mut buf: Vec<u8> = Vec::with_capacity(self.page_size);
+      for _ in 0..self.page_size {
+        buf.push(0);
+      }
+      let page = Page::new(page_num, buf);
+      self.pages.insert(page_num, Some(page));
+    }
+
+    self.pages[page_num].as_mut().unwrap()
   }
 
   /// Grow the page buffer capacity to accomodate more elements.

--- a/tests/pager.rs
+++ b/tests/pager.rs
@@ -1,6 +1,6 @@
 extern crate memory_pager;
 
-use memory_pager::{Page, Pager};
+use memory_pager::Pager;
 
 #[test]
 fn can_create_default() {
@@ -17,12 +17,12 @@ fn can_get() {
   let mut pager = Pager::default();
   {
     let page = pager.get(0);
-    assert_eq!(page.buffer.len(), 1024);
+    assert_eq!(page.len(), 1024);
   }
 
   {
     let page = pager.get(3);
-    assert_eq!(page.buffer.len(), 1024);
+    assert_eq!(page.len(), 1024);
   }
 }
 
@@ -31,11 +31,21 @@ fn can_alloc() {
   let mut pager = Pager::default();
   {
     let page = &pager.get(16);
-    assert_eq!(page.buffer.len(), 1024);
+    assert_eq!(page.len(), 1024);
   }
 
   {
     let page = &pager.get(32);
-    assert_eq!(page.buffer.len(), 1024);
+    assert_eq!(page.len(), 1024);
   }
+}
+
+#[test]
+fn can_write() {
+  let mut pager = Pager::default();
+  let page = pager.get_mut(0);
+  page[0] = 1;
+
+  assert_eq!(1, page[0]);
+  assert_eq!(0, page[1]);
 }

--- a/tests/pager.rs
+++ b/tests/pager.rs
@@ -49,3 +49,11 @@ fn can_write() {
   assert_eq!(1, page[0]);
   assert_eq!(0, page[1]);
 }
+
+#[test]
+fn can_check_offset() {
+  let mut pager = Pager::default();
+  let page = pager.get(1);
+
+  assert_eq!(1024, page.offset());
+}


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request 😄 ! Before you submit, please read the following:
- Read our CONTRIBUTING.md file before submitting a patch.
- By making a contribution, you agree to our Developer Certificate of Origin.
-->

**Choose one:**  🙋 feature

<!-- Provide a general summary of the changes in the title above -->

Hides the internal data structure and exposes the `Page` as a byte slice, getting `Index`, `IndexMut`, `.len()`, etc. for free.
From the viewpoint of the user a `Page` acts exactly the same as a slice.


## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests pass
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added

## Context
#rustallhands discussion

## Semver Changes
<!-- Which semantic version change would you recommend? -->
