### PR TITLE
Iterator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_script: |
   rustup component add rustfmt-preview &&
   cargo install clippy -f
 script: |
-  cargo fmt -- --write-mode=diff &&
+  cargo fmt -- --check &&
   cargo clippy -- -D clippy &&
   cargo build --verbose &&
   cargo test  --verbose

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,6 @@
 #![feature(external_doc)]
 #![doc(include = "../README.md")]
 
-// #![feature(generic_associated_types)]
-
 mod page;
 mod pager;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,8 @@
 #![feature(external_doc)]
 #![doc(include = "../README.md")]
 
+// #![feature(generic_associated_types)]
+
 mod page;
 mod pager;
 

--- a/src/pager.rs
+++ b/src/pager.rs
@@ -157,8 +157,6 @@ pub struct Iter<'a> {
   cursor: usize,
 }
 
-// TODO: return a new struct that holds a lifetime so we can iterate over it.
-// The API should probably become `.iter()` which returns an iterator.
 impl<'a> iter::Iterator for Iter<'a> {
   type Item = &'a Option<Page>;
 

--- a/src/pager.rs
+++ b/src/pager.rs
@@ -139,6 +139,19 @@ impl Default for Pager {
 }
 
 /// Iterator over a `Pager` instance.
+///
+/// ```rust
+/// # extern crate memory_pager;
+/// # use memory_pager::Pager;
+/// let mut pager = Pager::default();
+/// pager.get_mut_or_alloc(1);
+/// pager.get_mut_or_alloc(2);
+/// pager.get_mut_or_alloc(3);
+///
+/// for page in pager.iter() {
+///   println!("page {:?}", page);
+/// }
+/// ```
 pub struct Iter<'a> {
   inner: &'a Pager,
   cursor: usize,

--- a/src/pager.rs
+++ b/src/pager.rs
@@ -134,24 +134,23 @@ impl Default for Pager {
   }
 }
 
-impl iter::Iterator for Pager {
-  type Item = Option<borrow::Cow<Page>>;
+// TODO: return a new struct that holds a lifetime so we can iterate over it.
+// The API should probably become `.iter()` which returns an iterator.
+impl<'a> iter::Iterator for Pager {
+  type Item = &'a Option<Page>;
 
-  fn next(&mut self) -> Option<Self::Item> {
+  fn next(&mut self) -> Option<&Self::Item> {
     let cursor = self.cursor;
     self.cursor += 1;
 
     if cursor >= self.length {
       None
     } else {
-      match self.pages.get(cursor) {
-        Some(page) => Some(borrow::Cow::Borrowed(page)),
-        None => None,
-      }
+      self.pages.get(cursor)
     }
   }
 
-  fn size_hint(&self) -> (usize, Option<usize>) {
-    (0, Some(self.len()))
-  }
+  // fn size_hint(&self) -> (usize, Option<usize>) {
+  //   (0, Some(self.len()))
+  // }
 }

--- a/src/pager.rs
+++ b/src/pager.rs
@@ -73,10 +73,7 @@ impl Pager {
   pub fn get(&mut self, page_num: usize) -> Option<&Page> {
     match self.pages.get(page_num) {
       None => None,
-      Some(page) => match page.as_ref() {
-        None => None,
-        Some(page) => Some(page),
-      },
+      Some(page) => page.as_ref(),
     }
   }
 
@@ -87,10 +84,7 @@ impl Pager {
   pub fn get_mut(&mut self, page_num: usize) -> Option<&mut Page> {
     match self.pages.get_mut(page_num) {
       None => None,
-      Some(page) => match page.as_mut() {
-        None => None,
-        Some(page) => Some(page),
-      },
+      Some(page) => page.as_mut(),
     }
   }
 
@@ -113,13 +107,15 @@ impl Pager {
 
   /// The number of pages held by `memory-pager`. Doesn't account for empty
   /// entries. Comparable to `vec.len()` in usage.
+  #[inline]
   pub fn len(&self) -> usize {
     self.length
   }
 
   /// check whether the `length` is zero.
+  #[inline]
   pub fn is_empty(&self) -> bool {
-    self.length == 0
+    self.len() == 0
   }
 }
 

--- a/src/pager.rs
+++ b/src/pager.rs
@@ -1,5 +1,5 @@
 use super::*;
-use std::{borrow, iter};
+use std::iter;
 
 /// Memory pager instance. Manages [`Page`] instances.
 ///
@@ -11,8 +11,6 @@ pub struct Pager {
   /// A vector of pages that are held in memory.
   pub pages: Vec<Option<Page>>,
   length: usize,
-  /// Position in the iterator.
-  cursor: usize,
 }
 
 impl Pager {
@@ -24,7 +22,6 @@ impl Pager {
     Pager {
       page_size,
       length: 0,
-      cursor: 0,
       pages: vec![None; 16],
     }
   }
@@ -43,7 +40,6 @@ impl Pager {
     }
 
     Pager {
-      cursor: 0,
       page_size,
       length: pages.len(),
       pages,
@@ -122,6 +118,14 @@ impl Pager {
   pub fn is_empty(&self) -> bool {
     self.len() == 0
   }
+
+  /// Iterate over `&Pages`.
+  pub fn iter(&self) -> Iter {
+    Iter {
+      inner: &self,
+      cursor: 0,
+    }
+  }
 }
 
 /// Create a new [`Pager`] instance with a [`page_size`] of `1024`.
@@ -134,23 +138,25 @@ impl Default for Pager {
   }
 }
 
+/// Iterator over a `Pager` instance.
+pub struct Iter<'a> {
+  inner: &'a Pager,
+  cursor: usize,
+}
+
 // TODO: return a new struct that holds a lifetime so we can iterate over it.
 // The API should probably become `.iter()` which returns an iterator.
-impl<'a> iter::Iterator for Pager {
+impl<'a> iter::Iterator for Iter<'a> {
   type Item = &'a Option<Page>;
 
-  fn next(&mut self) -> Option<&Self::Item> {
+  fn next(&mut self) -> Option<Self::Item> {
     let cursor = self.cursor;
     self.cursor += 1;
 
-    if cursor >= self.length {
+    if cursor >= self.inner.len() {
       None
     } else {
-      self.pages.get(cursor)
+      self.inner.pages.get(cursor)
     }
   }
-
-  // fn size_hint(&self) -> (usize, Option<usize>) {
-  //   (0, Some(self.len()))
-  // }
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -81,3 +81,19 @@ fn set_122() {
   let pager = &mut Pager::default();
   pager.get_mut_or_alloc(122);
 }
+
+#[test]
+fn can_iterate_over_pager() {
+  let mut pager = Pager::default();
+  pager.get_mut_or_alloc(0);
+  pager.get_mut_or_alloc(2);
+
+  for (i, page) in pager.iter().enumerate() {
+    match i {
+      0 => assert!(page.is_some(), "0 is some"),
+      1 => assert!(page.is_none(), "1 is none"),
+      2 => assert!(page.is_some(), "2 is some"),
+      i => panic!("Index {} out of bounds", i),
+    }
+  }
+}

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -97,3 +97,20 @@ fn can_iterate_over_pager() {
     }
   }
 }
+
+#[test]
+fn can_iterate_over_pages() {
+  let mut pager = Pager::default();
+  pager.get_mut_or_alloc(0);
+
+  for page in pager.iter() {
+    match page {
+      None => panic!("Index 0 should contain a page"),
+      Some(page) => {
+        for num in page.iter() {
+          assert_eq!(*num, 0);
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Implement an iterator over `Pager`, which allows us to iterate over all pages, returning `Option<Page>`.

Also did a bit of cleanup, removing dead code along the way.

This should allow us to efficiently apply RLE encoding when we need to (which is soon!). So no more need to concat the whole thing into a buffer, but instead we can iterate over all values, and return `None` when we have an empty page.

Thanks!