### PR TITLE
Simplify implementation

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,5 +1,5 @@
 use super::{Page, Pager};
-use std::iter;
+use std::{iter, slice};
 
 /// Iterator over a `Pager` instance.
 ///
@@ -16,16 +16,14 @@ use std::iter;
 /// }
 /// ```
 pub struct Iter<'a> {
-  inner: &'a Pager,
-  cursor: usize,
+  inner: slice::Iter<'a, Option<Page>>,
 }
 
 impl<'a> Iter<'a> {
   #[inline]
   pub(crate) fn new(pager: &'a Pager) -> Self {
     Self {
-      inner: pager,
-      cursor: 0,
+      inner: pager.pages.iter(),
     }
   }
 }
@@ -34,13 +32,6 @@ impl<'a> iter::Iterator for Iter<'a> {
   type Item = &'a Option<Page>;
 
   fn next(&mut self) -> Option<Self::Item> {
-    let cursor = self.cursor;
-    self.cursor += 1;
-
-    if cursor >= self.inner.len() {
-      None
-    } else {
-      self.inner.pages.get(cursor)
-    }
+    self.inner.next()
   }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,6 @@ pub use page::Page;
 #[derive(Debug)]
 pub struct Pager {
   pages: Vec<Option<Page>>,
-  length: usize,
   page_size: usize,
 }
 
@@ -27,8 +26,7 @@ impl Pager {
   pub fn new(page_size: usize) -> Self {
     Pager {
       page_size,
-      length: 0,
-      pages: vec![None; 16],
+      pages: Vec::new(),
     }
   }
 
@@ -48,11 +46,7 @@ impl Pager {
       }
     }
 
-    Pager {
-      length: pages.len(),
-      page_size,
-      pages,
-    }
+    Pager { page_size, pages }
   }
 
   /// Get a [`Page`] mutably. The page will be allocated on first access.
@@ -68,10 +62,6 @@ impl Pager {
       let buf = vec![0; self.page_size];
       let page = Page::new(page_num, buf);
       self.pages[page_num] = Some(page);
-    }
-
-    if page_num > self.length {
-      self.length = page_num + 1;
     }
 
     self.pages[page_num].as_mut().unwrap()
@@ -100,32 +90,20 @@ impl Pager {
 
   /// Grow the page buffer capacity to accommodate more elements.
   fn grow_pages(&mut self, index: usize) {
-    let start_len = self.pages.len();
-    let mut new_len = start_len * 2;
-
-    // Guard against a page size of 0.
-    if new_len == 0 {
-      new_len += 1
-    }
-
-    while new_len <= index {
-      new_len *= 2;
-    }
-
-    self.pages.resize(new_len, None);
+    self.pages.resize(index + 1, None);
   }
 
   /// The number of pages held by `memory-pager`. Doesn't account for empty
   /// entries. Comparable to `vec.len()` in usage.
   #[inline]
   pub fn len(&self) -> usize {
-    self.length
+    self.pages.len()
   }
 
   /// check whether the `length` is zero.
   #[inline]
   pub fn is_empty(&self) -> bool {
-    self.len() == 0
+    self.pages.is_empty()
   }
 
   /// Get the memory page size in bytes.

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -114,3 +114,24 @@ fn can_iterate_over_pages() {
     }
   }
 }
+
+#[test]
+fn length() {
+  let mut pager = Pager::new(1024);
+  assert_eq!(pager.len(), 0);
+
+  pager.get_mut_or_alloc(0);
+  assert_eq!(pager.len(), 1);
+
+  pager.get_mut_or_alloc(10);
+  assert_eq!(pager.len(), 11);
+
+  pager.get_mut_or_alloc(1536);
+  assert_eq!(pager.len(), 1537);
+
+  pager.get_mut_or_alloc(1537);
+  assert_eq!(pager.len(), 1538);
+
+  pager.get_mut_or_alloc(1536512);
+  assert_eq!(pager.len(), 1536513);
+}


### PR DESCRIPTION
This PR simplifies the buffer handling and the iterator implementation, and fixes a bug in the process:

1. `Vec` tracks its capacity and length, so no need to duplicate these. This change alters the allocation strategy somewhat, but I don't think it matters at this point. Currently, it's growing a bit slower or at most at the same rate but it's an implementation detail of `Vec`, so it can change any time.

1. The iterator implementation can reuse the iterator implementation of slice without any change in behavior.

## Checklist
- [x] tests pass

## Semver Changes
patch level
