### PR TITLE
Fix bug: read file to buf not only once

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memory-pager"
-version = "0.6.2-alpha.0"
+version = "0.7.0"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/datrs/memory-pager"
 documentation = "https://docs.rs/memory-pager"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memory-pager"
-version = "0.7.0"
+version = "0.7.1-alpha.0"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/datrs/memory-pager"
 documentation = "https://docs.rs/memory-pager"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,7 +105,7 @@ impl Pager {
         pages.push(None);
       } else {
         pages.push(Some(Page::new(index, buf)));
-        buf = Vec::with_capacity(page_size);
+        buf = vec![0; page_size];
       }
     }
 

--- a/tests/fixtures/40_normal.txt
+++ b/tests/fixtures/40_normal.txt
@@ -1,0 +1,1 @@
+abcdefghijabcdefghijabcdefghijabcdefghij

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -163,5 +163,12 @@ fn can_recreate_from_file() -> Result<(), Error> {
   assert!(pager.get(3).is_some());
   assert!(pager.get(8).is_none());
 
+  let mut file = fs::File::open("./tests/fixtures/40_normal.txt")?;
+  let pager = Pager::from_file(&mut file, page_size, None)?;
+  assert!(pager.get(0).is_some());
+  assert!(pager.get(1).is_some());
+  assert!(pager.get(2).is_some());
+  assert!(pager.get(3).is_some());  
+
   Ok(())
 }


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request 😄 ! Before you submit, please read the following:
- Read our CONTRIBUTING.md file before submitting a patch.
- By making a contribution, you agree to our Developer Certificate of Origin.
-->

This is a 🐛 bug fix

<!-- Provide a general summary of the changes in the title above -->
In the `fn from_file()`, `file` only read to `buf` once, because the second time, bytes_read is 0, then the loop break.

To fix it, use `buf = vec![0; page_size];` instead of `buf = Vec::with_capacity(page_count);` 
https://github.com/datrs/memory-pager/blob/907cf16695fbba2b4a472c72e484d41fd2bcff41/src/lib.rs#L108

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests pass
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added

## Context
No

## Semver Changes
Patch
