### PR TITLE
Keep up with modern times in clippy invocation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,10 @@ rust:
 
 before_script: |
   rustup component add rustfmt-preview &&
-  cargo install clippy -f
+  rustup component add clippy-preview
 script: |
   cargo fmt -- --check &&
-  cargo clippy -- -D clippy &&
+  cargo clippy -- -D clippy::all &&
   cargo build --verbose &&
   cargo test  --verbose
 cache: cargo

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -168,7 +168,7 @@ fn can_recreate_from_file() -> Result<(), Error> {
   assert!(pager.get(0).is_some());
   assert!(pager.get(1).is_some());
   assert!(pager.get(2).is_some());
-  assert!(pager.get(3).is_some());   
+  assert!(pager.get(3).is_some());
 
-  Ok(()) 
+  Ok(())
 }


### PR DESCRIPTION
This is a 🐛 bug fix.

Fixes the following warning:
`warning: lint name `clippy` is deprecated and does not have an effect anymore. Use: clippy::all`

## Checklist

- [x] tests pass
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added

## Semver Changes
None